### PR TITLE
20250630: finalize loader to db script & several hotfixes

### DIFF
--- a/airflow/dags/01_dag_weather_generate_json_daily.py
+++ b/airflow/dags/01_dag_weather_generate_json_daily.py
@@ -45,9 +45,9 @@ def set_env_vars(**kwargs):
     """
     Push EMPTY_RATE and ERROR_RATE into XCom for downstream tasks.
     """
-    # Draw rates from a triangular distribution with mode=10
-    empty_rate = 0 ### [WIP] int(random.triangular(0, 100, 10))
-    error_rate = 0 ### [WIP] int(random.triangular(0, 100, 10))
+    # Draw rates from a triangular distribution with mode=5
+    empty_rate = 0 ### [WIP] int(random.triangular(0, 100, 5))
+    error_rate = 0 ### [WIP] int(random.triangular(0, 100, 5))
 
     # Assemble environment dict
     env = {

--- a/airflow/dags/02_dag_weather_json_to_parquet_daily.py
+++ b/airflow/dags/02_dag_weather_json_to_parquet_daily.py
@@ -5,7 +5,7 @@
 
 # -- Imports: Airflow core, operators, and Python stdlib
 from airflow import DAG
-from airflow.models import Variable
+from airflow.sdk import Variable
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup

--- a/airflow/dags/03_dag_weather_load_parquet_daily.py
+++ b/airflow/dags/03_dag_weather_load_parquet_daily.py
@@ -5,7 +5,7 @@
 
 # -- Imports: Airflow core, operators, and Python stdlib
 from airflow import DAG
-from airflow.models import Variable
+from airflow.sdk import Variable
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - .env
     environment:
       - AIRFLOW__CORE__AIRFLOW_HOME=/opt/airflow
-      - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres_airflow:5432/airflow
+      - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow?currentSchema=airflow
       - AIRFLOW__CORE__EXECUTOR=LocalExecutor
       - PYTHONPATH=/opt/project
     volumes:
@@ -24,19 +24,6 @@ services:
       - postgres
       - minio
     command: ["bash","-c","exec airflow standalone"]
-
-  postgres_airflow:
-    image: postgres:latest
-    env_file:
-      - .env
-    environment:
-      - POSTGRES_DB=${AIRFLOW_DB_NAME}
-      - POSTGRES_USER=${AIRFLOW_DB_USER}
-      - POSTGRES_PASSWORD=${AIRFLOW_DB_PASS}
-    volumes:
-      - postgres-airflow-data:/var/lib/postgresql/data
-    ports:
-      - "${AIRFLOW_DB_PORT}:5432"
 
   postgres:
     image: postgres:latest

--- a/scripts/loader_parquet_to_db.py
+++ b/scripts/loader_parquet_to_db.py
@@ -55,35 +55,9 @@ class ParquetLoader:
                 self.helper.check_and_create_table(conn, self.table, 'raw', df)
                 
                 # Merge data into main table
-                # self.helper.merge_data_into_table(conn, df, self.table, 'raw', self.exec_date)
+                self.helper.truncate_insert_data(conn, self.table, 'raw', df, self.exec_date)
         except Exception as e:
             logger.error(f"!! Error when merging data to main table @ {self.table} - {e}")
-
-
-
-
-
-
-
-# ################## TO DO 20250610
-#         # Write into Postgres: idempotent partition overwrite
-#         with self.engine.begin() as conn:
-#             # Delete existing partition for exec_date
-#             delete_sql = text(
-#                 f"DELETE FROM raw.{self.table} WHERE date = :d"
-#             )
-#             conn.execute(delete_sql, {'d': self.exec_date})
-#             logger.info(f"Deleted existing rows for {self.exec_date}")
-
-#             # Insert new data
-#             df.to_sql(
-#                 name=self.table,
-#                 con=conn,
-#                 schema='raw',
-#                 if_exists='append',
-#                 index=False
-#             )
-#             logger.info(f"Inserted {len(df)} rows into raw.{self.table}")
 
 
 def main():

--- a/scripts/sample_data_generator.py
+++ b/scripts/sample_data_generator.py
@@ -238,7 +238,6 @@ class DataGenerator:
             ("day", ["avgtemp_c", "avgtemp_f"]),
             ("day", ["maxwind_mph", "maxwind_kph"]),
             ("day", ["totalprecip_mm", "totalprecip_in"]),
-            ("day", ["totalsnow_cm"]),
             ("day", ["avgvis_km", "avgvis_miles"]),
         ]
         for city, city_data in data.items():
@@ -249,9 +248,16 @@ class DataGenerator:
 
                 # Inject into 'current' section if chosen
                 for section, keys in chosen_groups:
+
+                    # Randomly choose one key to be invalidated in the group
+                    key_to_invalidate = random.choice(keys)     # Select one of the pair
+
                     if section == "current":
-                        for k in keys:
-                            city_data["current"][k] = "invalid_data"
+                        city_data["current"][key_to_invalidate] = "invalid_data"
+
+                    elif section == "day":
+                        # Randomly choose one key in the "day" section to invalidate
+                        city_data["forecast"]["forecastday"][0]["day"][key_to_invalidate] = "invalid_data"
 
                 # Determine forecast forecasts length
                 forecast_days = city_data.get("forecast", {}).get("forecastday", [])


### PR DESCRIPTION
## _20250630_

## Summary:
This pull request includes several updates and fixes to improve the data processing pipeline and Airflow DAGs. It contains a hotfix for the alter schema function in the ETL utilities, ensuring proper handling of column data types. The dtype mapping for PostgreSQL is now managed in a separate function for better modularity. The sample data generator logic has been updated to ensure that only one key is removed from a group, rather than both. Additionally, the mode in DAG 01 has been changed from 10 to 5. Airflow database metadata is being moved to the main PostgreSQL in the airflow schema, with this change to be fully applied after an upcoming Docker Compose down operation. Modifications to DAGs 02 and 03 now utilize airflow.sdk, and the merge process for the loader_parquet_to_db script has been updated to a truncate insert approach. Finally, the loader_parquet_to_db script has been finalized with these improvements.

## Done:
- Hotfix for the alter schema function in ETL utilities.
- Separated the dtype mapping for PostgreSQL into its own function.
- Updated sample data generator to ensure only one key disappears from a group.
- Changed mode in DAG 01 to 5 (previously 10).
- Moved Airflow DB metadata to the main PostgreSQL in the airflow schema -- (final step during Docker Compose down).
- Updated DAG 02 and 03 to use airflow.sdk.
- Refactored the merge process in the `loader_parquet_to_db` script to use truncate insert.
- Finalized the `loader_parquet_to_db` script.

## To Do:
- Data monitoring script
- Configure dbt